### PR TITLE
feat(dashboard): add disable commands page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea/
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/Select/SelectBoolean.tsx
+++ b/src/components/Select/SelectBoolean.tsx
@@ -6,7 +6,7 @@ export interface SelectBooleanProps {
 	currentValue: boolean;
 	description?: string;
 
-	onChange(...args: any[]): void;
+	onChange(isChecked: boolean): void;
 }
 
 export default function SelectBoolean({ title, currentValue, onChange, description }: SelectBooleanProps) {

--- a/src/meta/typings/ApiData.d.ts
+++ b/src/meta/typings/ApiData.d.ts
@@ -95,3 +95,16 @@ export interface FlattenedMember {
 	premiumSinceTimestamp: number | null;
 	roles: FlattenedRole[];
 }
+
+export interface FlattenedCommand {
+	bucket: number;
+	category: string;
+	cooldown: number;
+	description: string;
+	guarded: boolean;
+	guildOnly: boolean;
+	name: string;
+	permissionLevel: number;
+	requiredPermissions: string[];
+	usage: string;
+}

--- a/src/meta/util.ts
+++ b/src/meta/util.ts
@@ -34,6 +34,10 @@ export const saveState = (key: string, state: unknown) => {
 };
 
 export async function apiFetch(path: string, options: RequestInit = {}) {
+	if (process.env.NODE_ENV === 'development') {
+		await sleep(1000);
+	}
+
 	const response = await fetch(`${BASE_API_URL}${path}`, {
 		...options,
 		headers: {

--- a/src/pages/Commands.tsx
+++ b/src/pages/Commands.tsx
@@ -11,6 +11,7 @@ import DoubleArrowIcon from '@material-ui/icons/DoubleArrow';
 import LockIcon from '@material-ui/icons/Lock';
 import GeneralPage from 'components/GeneralPage';
 import Tooltip from 'components/Tooltip';
+import { FlattenedCommand } from 'meta/typings/ApiData';
 import { apiFetch, cutText } from 'meta/util';
 import React, { useEffect, useState } from 'react';
 import { Else, If, Then } from 'react-if';
@@ -62,23 +63,10 @@ const useStyles = makeStyles((theme: Theme) =>
 	})
 );
 
-interface Command {
-	bucket: number;
-	category: string;
-	cooldown: number;
-	description: string;
-	guarded: boolean;
-	guildOnly: boolean;
-	name: string;
-	permissionLevel: number;
-	requiredPermissions: string[];
-	usage: string;
-}
-
 export default () => {
 	const classes = useStyles();
 	const [loading, setLoading] = useState(true);
-	const [commands, setCommands] = useState<Command[]>([]);
+	const [commands, setCommands] = useState<FlattenedCommand[]>([]);
 
 	const titles: Record<number, string> = {
 		4: 'This command can only be run by staff members.',

--- a/src/pages/Dashboard/DisableCommandsPage.tsx
+++ b/src/pages/Dashboard/DisableCommandsPage.tsx
@@ -1,0 +1,210 @@
+import Backdrop from '@material-ui/core/Backdrop';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { green } from '@material-ui/core/colors';
+import Divider from '@material-ui/core/Divider';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import Grid from '@material-ui/core/Grid';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Section from 'components/Section';
+import SelectBoolean from 'components/Select/SelectBoolean';
+import { FlattenedCommand } from 'meta/typings/ApiData';
+import { SettingsPageProps } from 'meta/typings/GuildSettings';
+import { apiFetch } from 'meta/util';
+import React, { PropsWithChildren, useCallback, useEffect, useState } from 'react';
+
+const useStyles = makeStyles((theme: Theme) =>
+	createStyles({
+		backdrop: {
+			zIndex: theme.zIndex.drawer + 1,
+			color: theme.palette.primary.contrastText
+		},
+		expansionPanels: {
+			marginTop: theme.spacing(3)
+		},
+		cancelButton: {
+			backgroundColor: theme.palette.error.main,
+
+			'&:hover': {
+				backgroundColor: theme.palette.error.dark
+			}
+		},
+		disableAllButton: {
+			backgroundColor: theme.palette.secondary.main,
+			color: theme.palette.text.primary,
+
+			'&:hover': {
+				backgroundColor: theme.palette.secondary.dark,
+				color: theme.palette.text.primary
+			}
+		},
+		enableAllButton: {
+			backgroundColor: green[600],
+			color: theme.palette.text.primary,
+
+			'&:hover': {
+				backgroundColor: green[800],
+				color: theme.palette.text.primary
+			}
+		}
+	})
+);
+
+export default ({ guildSettings: { disabledCommands }, patchGuildData }: PropsWithChildren<SettingsPageProps>) => {
+	const classes = useStyles();
+	const [expanded, setExpanded] = useState<string | false>(false);
+	const [loading, setLoading] = useState(true);
+	const [commands, setCommands] = useState<Record<string, Command>>({});
+
+	const fetchCommands = useCallback(async () => {
+		const commands: FlattenedCommand[] = await apiFetch('/commands');
+		const commandsForState: Record<string, Command> = {};
+		for (const command of commands) {
+			if (command.guarded) continue;
+			commandsForState[command.name] = {
+				name: command.name,
+				description: command.description,
+				isEnabled: !disabledCommands.includes(command.name),
+				category: command.category
+			};
+		}
+		setCommands(commandsForState);
+		setLoading(false);
+	}, [disabledCommands]);
+
+	useEffect(() => {
+		fetchCommands();
+	}, [fetchCommands]);
+
+	const handleToggleExpansionPanel = (panel: string) => (_: React.ChangeEvent<{}>, isExpanded: boolean) => {
+		setExpanded(isExpanded ? panel : false);
+	};
+
+	const categories = [...new Set(Object.values(commands).map(command => command.category))];
+
+	return (
+		<>
+			<Backdrop className={classes.backdrop} open={loading}>
+				<CircularProgress color="primary" />
+			</Backdrop>
+			<Section title="Commands">
+				<Typography variant="subtitle2" color="textPrimary">
+					On this page you can disable commands on your server
+				</Typography>
+				<Box className={classes.expansionPanels}>
+					{categories.map((catName, catIndex) => (
+						<ExpansionPanel
+							key={catIndex}
+							expanded={expanded === catName}
+							onChange={handleToggleExpansionPanel(catName)}
+							TransitionProps={{ unmountOnExit: true }}
+						>
+							<ExpansionPanelSummary
+								expandIcon={<ExpandMoreIcon />}
+								aria-controls={`${catName}-content`}
+								id={`${catName}-header`}
+							>
+								<Typography variant="body1">{catName}</Typography>
+							</ExpansionPanelSummary>
+							<ExpansionPanelDetails>
+								<Grid container spacing={1} direction="row" justify="flex-start" alignItems="center" alignContent="center">
+									{Object.values(commands)
+										.filter(command => command.category === catName)
+										.map((cmd, idx) => (
+											<Grid item key={idx} xs={4}>
+												<SelectBoolean
+													title={cmd.name}
+													description={cmd.description}
+													currentValue={cmd.isEnabled}
+													onChange={isEnabled => {
+														return setCommands({ ...commands, [cmd.name]: { ...cmd, isEnabled } });
+													}}
+												/>
+											</Grid>
+										))}
+								</Grid>
+							</ExpansionPanelDetails>
+							<Divider />
+							<ExpansionPanelActions>
+								<Button
+									size="small"
+									variant="contained"
+									classes={{ root: classes.enableAllButton }}
+									onClick={() => {
+										const changedCommands: Record<string, Command> = {};
+										for (const command of Object.values(commands)) {
+											if (command.category !== catName) continue;
+											changedCommands[command.name] = {
+												...command,
+												isEnabled: true
+											};
+										}
+
+										return setCommands({
+											...commands,
+											...changedCommands
+										});
+									}}
+								>
+									Enable all
+								</Button>
+								<Button
+									size="small"
+									variant="contained"
+									classes={{ root: classes.disableAllButton }}
+									onClick={() => {
+										const changedCommands: Record<string, Command> = {};
+										for (const command of Object.values(commands)) {
+											if (command.category !== catName) continue;
+											changedCommands[command.name] = {
+												...command,
+												isEnabled: false
+											};
+										}
+
+										return setCommands({
+											...commands,
+											...changedCommands
+										});
+									}}
+								>
+									Disable all
+								</Button>
+								<Button size="small" variant="contained" classes={{ root: classes.cancelButton }} onClick={fetchCommands}>
+									Reset
+								</Button>
+								<Button
+									size="small"
+									color="primary"
+									variant="contained"
+									onClick={() => {
+										patchGuildData({
+											disabledCommands: Object.values(commands)
+												.filter(cmd => !cmd.isEnabled)
+												.map(cmd => cmd.name)
+										});
+									}}
+								>
+									Save
+								</Button>
+							</ExpansionPanelActions>
+						</ExpansionPanel>
+					))}
+				</Box>
+			</Section>
+		</>
+	);
+};
+
+interface Command {
+	name: string;
+	description: string;
+	isEnabled: boolean;
+	category: string;
+}

--- a/src/pages/Dashboard/EventsPage.tsx
+++ b/src/pages/Dashboard/EventsPage.tsx
@@ -67,10 +67,10 @@ export default (props: PropsWithChildren<SettingsPageProps>) => {
 							title={title}
 							description={description}
 							currentValue={props.guildSettings.events[key]}
-							onChange={r =>
+							onChange={isChecked =>
 								props.patchGuildData({
 									events: {
-										[key]: r
+										[key]: isChecked
 									}
 								})
 							}

--- a/src/pages/Dashboard/Root.js
+++ b/src/pages/Dashboard/Root.js
@@ -25,6 +25,7 @@ import CustomCommandsIcon from '@material-ui/icons/Extension';
 import FilterListIcon from '@material-ui/icons/FilterList';
 import ChannelsIcon from '@material-ui/icons/Forum';
 import GavelIcon from '@material-ui/icons/Gavel';
+import InputIcon from '@material-ui/icons/Input';
 import MenuIcon from '@material-ui/icons/Menu';
 import MessagesIcon from '@material-ui/icons/Message';
 import MusicIcon from '@material-ui/icons/MusicNote';
@@ -51,6 +52,7 @@ import { Else, If, Then } from 'react-if';
 import { Link, Switch } from 'react-router-dom';
 import React, { Fragment, useEffect, useState } from 'reactn';
 import ChannelsPage from './ChannelsPage';
+import DisableCommandsPage from './DisableCommandsPage';
 import InvitesFilterPage from './Filter/Invites';
 import MessagesFilterPage from './Filter/Messages';
 import NewLinesFilterPage from './Filter/NewLines';
@@ -452,6 +454,21 @@ const RootComponent = props => {
 						onClick={closeSidebarOnMobile}
 						disabled={!guildData}
 						component={Link}
+						to={`/guilds/${guildID}/disabled-commands`}
+						button
+					>
+						<ListItemIcon>
+							<InputIcon />
+						</ListItemIcon>
+						<ListItemText primary="Disable Commands" />
+					</ListItem>
+
+					{/* ------------------------------- */}
+
+					<ListItem
+						onClick={closeSidebarOnMobile}
+						disabled={!guildData}
+						component={Link}
 						to={`/guilds/${guildID}/custom-commands`}
 						button
 					>
@@ -605,6 +622,11 @@ const RootComponent = props => {
 									componentProps={{ ...componentProps }}
 									path="/guilds/:guildID/messages"
 									component={MessagesPage}
+								/>
+								<AuthenticatedRoute
+									componentProps={{ ...componentProps }}
+									path="/guilds/:guildID/disabled-commands"
+									component={DisableCommandsPage}
 								/>
 								<AuthenticatedRoute
 									componentProps={{ ...componentProps }}


### PR DESCRIPTION
As requested, a page to disable / enable commands

![22-42-10_22-04-2020_%pn](https://user-images.githubusercontent.com/4019718/80032159-0ee08e80-84eb-11ea-8d0f-47217fbe60c4.gif)
